### PR TITLE
Add use_vmac to the configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,5 +49,6 @@ ENV UNICAST_PEERS="192.168.2.101 192.168.2.102 192.168.2.103"
 ENV VIRTUAL_IPS="192.168.2.100/24"
 ENV PASSWORD="KeptAliv"
 ENV NOTIFY="/notify.sh"
+ENV USE_VMAC="false"
 
 CMD ["bash", "-x", "entrypoint.sh"]

--- a/assets/entrypoint.sh
+++ b/assets/entrypoint.sh
@@ -12,6 +12,11 @@ then
   sed -i "s|{{ PRIORITY }}|$PRIORITY|g" $CONFIG
   sed -i "s|{{ PASSWORD }}|$PASSWORD|g" $CONFIG
 
+  if [ "$USE_VMAC" = "true" ]; then
+    sed -i "s|{{ USE_VMAC }}|\use_vmac|g" $CONFIG
+  else
+    sed -i "/{{ USE_VMAC }}/d" $CONFIG
+  fi
 
   if [ -n "$NOTIFY" ]; then
     sed -i "s|{{ NOTIFY }}|\"$NOTIFY\"|g" $CONFIG

--- a/assets/entrypoint.sh
+++ b/assets/entrypoint.sh
@@ -13,7 +13,7 @@ then
   sed -i "s|{{ PASSWORD }}|$PASSWORD|g" $CONFIG
 
   if [ "$USE_VMAC" = "true" ]; then
-    sed -i "s|{{ USE_VMAC }}|\use_vmac|g" $CONFIG
+    sed -i "s|{{ USE_VMAC }}|use_vmac|g" $CONFIG
   else
     sed -i "/{{ USE_VMAC }}/d" $CONFIG
   fi

--- a/assets/keepalived.conf
+++ b/assets/keepalived.conf
@@ -18,6 +18,8 @@ vrrp_instance VI {
   priority {{ PRIORITY }}
   advert_int 1
 
+  {{ USE_VMAC }}
+
   unicast_peer {
     {{ UNICAST_PEERS }}
   }


### PR DESCRIPTION
It has been a while since i used sed, so any correction would be appreciated.
I have an use case where i need to use a virtual mac too, so i added the placeholder to the conf, added the ENV var to the Docker file and finally processed it in the entrypoint. I didn't test it, so, please review it carrefully. Thanks